### PR TITLE
Typo: 'alow_conn' --> 'low_conn'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ steps:
 
 - script: |
     python -m pip install --upgrade pip
-    pip install -r requirements.txt
+    # pip install -r requirements.txt
   displayName: 'Install dependencies'
 
 - script: |

--- a/requests3/adapters.py
+++ b/requests3/adapters.py
@@ -758,7 +758,7 @@ class AsyncHTTPAdapter(HTTPAdapter):
                     # Receive the response from the server
                     try:
                         # For Python 2.7, use buffering of HTTP responses
-                        r = alow_conn.getresponse(buffering=True)
+                        r = low_conn.getresponse(buffering=True)
                     except TypeError:
                         # For Python 3.3+ versions, this is the default
                         r = low_conn.getresponse()


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/kennethreitz/requests3 on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./requests3/adapters.py:761:29: F821 undefined name 'alow_conn'
                        r = alow_conn.getresponse(buffering=True)
                            ^
./requests3/utils.py:279:12: F821 undefined name 'collections'
    return collections.OrderedDict(value)
           ^
./requests3/utils.py:668:43: F821 undefined name 'parsed'
                    if address_in_network(parsed.hostname, proxy_ip):
                                          ^
./requests3/utils.py:677:30: F821 undefined name 'parsed'
            host_with_port = parsed.hostname
                             ^
./requests3/utils.py:678:16: F821 undefined name 'parsed'
            if parsed.port:
               ^
./requests3/utils.py:679:48: F821 undefined name 'parsed'
                host_with_port += ":{}".format(parsed.port)
                                               ^
./requests3/utils.py:937:65: F821 undefined name 'collections'
    is_io_type = not isinstance(data, (basestring, list, tuple, collections.Mapping))
                                                                ^
./requests3/models.py:817:43: F821 undefined name 'chunk_size'
                    chunk = self.raw.read(chunk_size)
                                          ^
./requests3/models.py:1204:49: F821 undefined name 'chunk_size'
                    chunk = await self.raw.read(chunk_size)
                                                ^
./requests3/auth.py:29:9: F821 undefined name 'warnings'
        warnings.warn(
        ^
./requests3/auth.py:38:9: F821 undefined name 'warnings'
        warnings.warn(
        ^
./requests3/core/_http/packages/ssl_match_hostname/_implementation.py:76:15: F821 undefined name 'unicode'
        obj = unicode(obj, encoding='ascii', errors='strict')
              ^
./tests/test_utils.py:274:24: F821 undefined name 'extract_zipped_paths'
        assert path == extract_zipped_paths(path)
                       ^
./tests/test_utils.py:283:26: F821 undefined name 'extract_zipped_paths'
        extracted_path = extract_zipped_paths(zipped_path)
                         ^
14    F821 undefined name 'alow_conn'
14
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree