### PR TITLE
Drop Python 2.7 support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Requests III is ready for today's web.
 -   `.netrc` Support
 -   Chunked Requests
 
-Requests officially supports Python 2.7 & 3.4–3.7, and runs great on
+Requests officially supports Python 3.4–3.7, and runs great on
 PyPy.
 
 Installation


### PR DESCRIPTION
What is the rational justification for creating a new library compatible with Python 2.7, since the expected release timeline of library is "before PyCon 2020" and End Of Life date (EOL, sunset date) for Python 2.7 is 2020?