### PR TITLE
[doc website] Add a nice search experience

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -23,6 +23,27 @@
 
 <p><iframe src="https://ghbtns.com/github-btn.html?user=kennethreitz&type=follow&count=false"
   allowtransparency="true" frameborder="0" scrolling="0" width="200" height="20"></iframe></p>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+<style>
+.algolia-autocomplete{
+  width: 100%;
+  height: 1.5em
+}
+.algolia-autocomplete a{
+  border-bottom: none !important;
+}
+#doc_search{
+  width: 100%;
+  height: 100%;
+}
+</style>
+<input id="doc_search" placeholder="Search the doc" autofocus/>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js" onload="docsearch({
+  apiKey: 'b3e5b075bc802b547c1c0febb48c2bab',
+  indexName: 'requests3',
+  inputSelector: '#doc_search',
+  debug: false // Set debug to true if you want to inspect the dropdown
+})" async></script>
 
 <p><a href="https://twitter.com/kennethreitz" class="twitter-follow-button" data-show-count="false">Follow @kennethreitz</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></p>
 <p><a href="https://tinyletter.com/kennethreitz">Join Mailing List</a>.</p>

--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -28,6 +28,27 @@
 
 <p><iframe src="https://ghbtns.com/github-btn.html?user=kennethreitz&type=follow&count=false"
   allowtransparency="true" frameborder="0" scrolling="0" width="200" height="20"></iframe></p>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+<style>
+.algolia-autocomplete{
+  width: 100%;
+  height: 1.5em
+}
+.algolia-autocomplete a{
+  border-bottom: none !important;
+}
+#doc_search{
+  width: 100%;
+  height: 100%;
+}
+</style>
+<input id="doc_search" placeholder="Search the doc" autofocus/>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js" onload="docsearch({
+  apiKey: 'b3e5b075bc802b547c1c0febb48c2bab',
+  indexName: 'requests3',
+  inputSelector: '#doc_search',
+  debug: false // Set debug to true if you want to inspect the dropdown
+})" async></script>
 
 <p><a href="https://twitter.com/kennethreitz" class="twitter-follow-button" data-show-count="false">Follow @kennethreitz</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></p>
 


### PR DESCRIPTION
👋 team,

TL;DR: Add same search experience as https://pipenv.readthedocs.io/en/latest/

I'm working at Algolia on the a project called [DocSearch](https://community.algolia.com/docsearch/) which goal is to enhance documentation websites with exhaustive, fast and relevant search. You might have seen DocSearch live already on websites like [pipenv](https://pipenv.readthedocs.io/en/latest/), [Bootstrap](https://getbootstrap.com/), [Brew](https://brew.sh/) or [jQuery](https://jquery.com/).

I have created [a preview of this PR](https://docsearch-requests3.netlify.com/) and what DocSearch on the requests3 website could will look like here. Feel free to try it and let us know what you think. Please not the learn-as-you-type experience and the typo tolerance:

[![demo of DocSearch + requests3](https://cl.ly/f678924353fd/download/Screen%20Recording%202019-04-22%20at%2010.13%20PM.gif)](https://docsearch-requests3.netlify.com/)

The way DocSearch works is by crawling your content, pushing the results into an Algolia index, and then requesting this index directly from the website front-end through JavaScript.

We'll take care of crawling your website and populating the Algolia index with the latest changes every 24h for you. You don't need to change anything to your deployment process. The only thing you need to add are the following CSS and JS snippets that will bind the dropdown to your searchbox.

We built DocSearch with the idea of giving back to the Open-Source community. This is why your [crawling configuration](https://github.com/algolia/docsearch-configs/blob/master/configs/requests3.json) is available on GitHub if you want to change it. We also have our own [documentation](https://community.algolia.com/docsearch/documentation/) to help you tweak the dropdown to your needs. You'll also have access to *analytics on the most searched terms* or those with *no results*. All of this is of course *entirely free*.

Follow realpython/python-guide#932, pypa/pipenv#3703, kennethreitz/requests-html#292