### PR TITLE
Fix typos and repeated paragraphs in documentation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -194,3 +194,4 @@ Patches and Suggestions
 - Antti Kaihola (`@akaihola <https://github.com/akaihola>`_)
 - Hugo van Kemenade (`@hugovk <https://github.com/hugovk>`_)
 - Allan Crooks (`@the-allanc <https://github.com/the-allanc>`_)
+- Kasper Karlsson (`@kasperkarlsson <https://github.com/kasperkarlsson>`_)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,7 @@ HTTP connection pooling are 100% automatic, as well.
 
 Besides, all the cool kids are doing it. Requests is one of the most
 downloaded Python packages of all time, pulling in over ~1.6 million
-installations *per day*!
+installations *per day*! Join the party!
 
 User Testimonials
 -----------------
@@ -67,9 +67,6 @@ User Testimonials
 **Kenny Meyers**—
     *Python HTTP: When in doubt, or when not in doubt, use Requests. Beautiful,
     simple, Pythonic.*
-
-Requests is one of the most downloaded Python packages of all time, pulling in
-pulling in over ~1.6 million installations *per day*!. Join the party!
 
 If your organization uses Requests internally, consider `supporting the development of 3.0 <https://cash.me/$KennethReitz>`_.
 


### PR DESCRIPTION
Combined two very similar paragraphs and removed two typos.