### PR TITLE
BUG: timeout argument / kwarg passthrough

### DIFF
--- a/requests3/core/__init__.py
+++ b/requests3/core/__init__.py
@@ -6,7 +6,7 @@ __all__ = ["request", "blocking_request"]
 async def request(
     method,
     url,
-    timeout,
+    timeout, # should this pass through?
     *,
     data=None,
     headers=None,
@@ -17,6 +17,7 @@ async def request(
     """Returns a Response object, to be awaited."""
     if not client:
         client = http3.AsyncClient()
+    kwargs['timeout'] = kwargs.get('timeout', timeout)
     return await client.request(
         method=method,
         url=url,
@@ -30,7 +31,7 @@ async def request(
 def blocking_request(
     method,
     url,
-    timeout,
+    timeout,  # should this pass through?
     *,
     data=None,
     headers=None,
@@ -41,6 +42,7 @@ def blocking_request(
     """Returns a Response object."""
     if not client:
         client = http3.Client()
+    kwargs['timeout'] = kwargs.get('timeout', timeout)
     with client as http:
         r = http.request(
             method=method,


### PR DESCRIPTION
At a glance, should the timeout parameter pass through to client.request / http.request in kwargs?